### PR TITLE
use built-in root keys

### DIFF
--- a/files/named.conf
+++ b/files/named.conf
@@ -11,25 +11,13 @@ options {
 
         # DNSSEC
         dnssec-enable yes;
-        dnssec-validation yes;
+        dnssec-validation auto;
 
         # Statistics
         directory "/var/named";
         dump-file "/var/named/data/cache_dump.db";
         statistics-file "/var/named/data/named_stats.txt";
         memstatistics-file "/var/named/data/named.memstats";
-};
-
-// Root key.
-managed-keys {
-  "." initial-key 257 3 8
-    "AwEAAagAIKlVZrpC6Ia7gEzahOR+9W29euxhJhVVLOyQbSEW0O8gcCjF
-     FVQUTf6v58fLjwBd0YI0EzrAcQqBGCzh/RStIoO8g0NfnfL2MTJRkxoX
-     bfDaUeVPQuYEhg37NZWAJQ9VnMVDxP/VHL496M/QZxkjf5/Efucp2gaD
-     X6RS6CXpoY68LsvPVjR0ZSwzz1apAzvN9dlzEheX7ICJBBtuA6G3LQpz
-     W5hOA2hzCTMjJPJ8LbqF6dsV6DoBQzgul0sGIcGOYl7OyQdXfZ57relS
-     Qageu+ipAdTTJ25AsRTAoub8ONGcLmqrAmRLKBP1dfwhYB4N7knNnulq
-     QxA+Uk1ihz0=";
 };
 
 # RNDC


### PR DESCRIPTION
Specifying a root key is unnecessary in named.conf; "dnssec-validation auto;" uses a set of keys that are provided with BIND and have been updated to include KSK2017.